### PR TITLE
Introduced class_option for controller based generators to change the default_routes_file

### DIFF
--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -266,7 +266,7 @@ module Rails
       #
       #   route "root 'welcome#index'"
       #   route "root 'admin#index'", namespace: :admin
-      def route(routing_code, namespace: nil)
+      def route(routing_code, namespace: nil, default_routes_file: "config/routes.rb")
         routing_code = Array(namespace).reverse.reduce(routing_code) do |code, ns|
           "namespace :#{ns} do\n#{optimize_indentation(code, 2)}end"
         end
@@ -281,12 +281,12 @@ module Rails
         end
 
         in_root do
-          if existing = match_file("config/routes.rb", after_pattern)
+          if existing = match_file(default_routes_file, after_pattern)
             base_indent, *, prev_indent = existing.captures.compact.map(&:length)
             routing_code = optimize_indentation(routing_code, base_indent + 2).lines.grep_v(/^[ ]{,#{prev_indent}}\S/).join
           end
 
-          inject_into_file "config/routes.rb", routing_code, after: after_pattern, verbose: false, force: false
+          inject_into_file default_routes_file, routing_code, after: after_pattern, verbose: false, force: false
         end
       end
 

--- a/railties/lib/rails/generators/rails/controller/controller_generator.rb
+++ b/railties/lib/rails/generators/rails/controller/controller_generator.rb
@@ -5,6 +5,7 @@ module Rails
     class ControllerGenerator < NamedBase # :nodoc:
       argument :actions, type: :array, default: [], banner: "action action"
       class_option :skip_routes, type: :boolean, desc: "Don't add routes to config/routes.rb."
+      class_option :routes_file, type: :string, desc: "Alternative file to add routes instead of config/routes.rb"
       class_option :helper, type: :boolean
       class_option :assets, type: :boolean
 
@@ -18,7 +19,8 @@ module Rails
         return if options[:skip_routes]
         return if actions.empty?
         routing_code = actions.map { |action| "get '#{file_name}/#{action}'" }.join("\n")
-        route routing_code, namespace: regular_class_path
+        default_routes_file = options[:routes_file] || "config/routes.rb"
+        route routing_code, namespace: regular_class_path, default_routes_file: default_routes_file
       end
 
       hook_for :template_engine, :test_framework, :helper, :assets do |generator|

--- a/railties/lib/rails/generators/rails/resource_route/resource_route_generator.rb
+++ b/railties/lib/rails/generators/rails/resource_route/resource_route_generator.rb
@@ -16,7 +16,8 @@ module Rails
       #   end
       def add_resource_route
         return if options[:actions].present?
-        route "resources :#{file_name.pluralize}", namespace: regular_class_path
+        default_routes_file = options[:routes_file] || "config/routes.rb"
+        route "resources :#{file_name.pluralize}", namespace: regular_class_path, default_routes_file: default_routes_file
       end
     end
   end

--- a/railties/lib/rails/generators/rails/scaffold_controller/scaffold_controller_generator.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/scaffold_controller_generator.rb
@@ -30,8 +30,8 @@ module Rails
       end
 
       hook_for :resource_route, required: true do |route|
-        default_routes_file = options[:routes_file] || "config/routes.rb"
-        invoke route, default_routes_file: default_routes_file unless options.skip_routes?
+        routes_file = options[:routes_file] || "config/routes.rb"
+        invoke route, [ controller_name ], { routes_file: routes_file } unless options.skip_routes?
       end
 
       hook_for :test_framework, as: :scaffold

--- a/railties/lib/rails/generators/rails/scaffold_controller/scaffold_controller_generator.rb
+++ b/railties/lib/rails/generators/rails/scaffold_controller/scaffold_controller_generator.rb
@@ -16,6 +16,7 @@ module Rails
                          desc: "Generates API controller"
 
       class_option :skip_routes, type: :boolean, desc: "Don't add routes to config/routes.rb."
+      class_option :routes_file, type: :string, desc: "Alternative file to add routes instead of config/routes.rb"
 
       argument :attributes, type: :array, default: [], banner: "field:type field:type"
 
@@ -29,7 +30,8 @@ module Rails
       end
 
       hook_for :resource_route, required: true do |route|
-        invoke route unless options.skip_routes?
+        default_routes_file = options[:routes_file] || "config/routes.rb"
+        invoke route, default_routes_file: default_routes_file unless options.skip_routes?
       end
 
       hook_for :test_framework, as: :scaffold

--- a/railties/test/generators/controller_generator_test.rb
+++ b/railties/test/generators/controller_generator_test.rb
@@ -75,6 +75,12 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_routes_file
+    copy_routes(default_routes_folder: "config/routes", default_routes_file: "base.rb")
+    run_generator ["account", "foo", "--routes-file", "config/routes/base.rb"]
+    assert_file "config/routes/base.rb", /^  get 'account\/foo'/
+  end
+
   def test_skip_routes_prevents_generating_tests_with_routes
     run_generator ["account", "foo", "--skip-routes"]
     assert_file "test/controllers/account_controller_test.rb" do |controller_test|

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -64,11 +64,11 @@ module GeneratorsTestHelper
     ActiveRecord::Base.configurations = original_configurations
   end
 
-  def copy_routes
+  def copy_routes(default_routes_folder: "config", default_routes_file: "routes.rb")
     routes = File.expand_path("../../lib/rails/generators/rails/app/templates/config/routes.rb.tt", __dir__)
-    destination = File.join(destination_root, "config")
+    destination = File.join(destination_root, default_routes_folder)
     FileUtils.mkdir_p(destination)
-    FileUtils.cp routes, File.join(destination, "routes.rb")
+    FileUtils.cp routes, File.join(destination, default_routes_file)
   end
 
   def copy_gemfile(*gemfile_entries)

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -116,6 +116,15 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_controller_route_are_added_to_routes_file
+    copy_routes(default_routes_folder: "config/routes", default_routes_file: "base.rb")
+    run_generator ["Message", "photos:attachments", "--routes-file", "config/routes/base.rb"]
+
+    assert_file "config/routes/base.rb" do |route|
+      assert_match(/resources :messages$/, route)
+    end
+  end
+
   def test_helper_are_invoked_with_a_pluralized_name
     run_generator
     assert_file "app/helpers/users_helper.rb", /module UsersHelper/


### PR DESCRIPTION
### Summary

When the list of routes are too many, developers tend to break down them into multiple files for better readability and clarity. During that approach, we move away from default `config/routes.rb`. But this has been configured by `route` to add actions/resources on certain generator calls.

The current proposed PR provides overriding ability of the default behavior i.e, adding to `config/routes.rb`, instead add it to an user defined routes file.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

Signed-off-by: Naveen Honest Raj K <naveendurai19@gmail.com>